### PR TITLE
opentelemetry plus bugfixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,4 +32,4 @@ workflows:              # keyword
             parameters: # keyword
               # All rubies being maintained per this page:
               # https://www.ruby-lang.org/en/downloads/branches/
-              ruby-version: [ "2.6", "2.7", "3.0", "3.1" ]
+              ruby-version: [ "2.5", "2.6", "2.7", "3.0" ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,4 +32,4 @@ workflows:              # keyword
             parameters: # keyword
               # All rubies being maintained per this page:
               # https://www.ruby-lang.org/en/downloads/branches/
-              ruby-version: [ "2.5", "2.6", "2.7", "3.0" ]
+              ruby-version: [ "2.6", "2.7", "3.0", "3.1" ]

--- a/lib/log_method/bugsnag_after_log.rb
+++ b/lib/log_method/bugsnag_after_log.rb
@@ -1,11 +1,12 @@
 class LogMethod::BugsnagAfterLog
   def self.call(class_thats_logging_name, method_name, object_id, object_class_name, trace_id, current_actor_id, _log_message)
+    current_actor_id_attribute = LogMethod.config.current_actor_id_label.to_sym
     Bugsnag.leave_breadcrumb method_name.to_s[0..29], {
       class: class_thats_logging_name,
       object_id: object_id,
       object_class: object_class_name,
       trace_id: trace_id,
-      admin_user_id: current_actor_id
+      current_actor_id_attribute => current_actor_id,
     }, Bugsnag::Breadcrumbs::LOG_BREADCRUMB_TYPE
   end
 end

--- a/lib/log_method/config.rb
+++ b/lib/log_method/config.rb
@@ -1,6 +1,6 @@
 class LogMethod::Config
-  attr_accessor :after_log_proc,
-                :current_actor_id_label,
+  attr_reader   :after_log_procs
+  attr_accessor :current_actor_id_label,
                 :current_actor_proc,
                 :external_identifier_method,
                 :trace_id_proc
@@ -10,11 +10,15 @@ class LogMethod::Config
   end
 
   def reset!
-    @after_log_proc             = NO_OP
+    @after_log_procs            = []
     @current_actor_id_label     = "current_actor_id"
     @current_actor_proc         = NO_OP
     @external_identifier_method = nil
     @trace_id_proc              = NO_OP
+  end
+
+  def after_log_proc=(proc_or_array)
+    @after_log_procs = Array(proc_or_array)
   end
 
 private

--- a/lib/log_method/log.rb
+++ b/lib/log_method/log.rb
@@ -34,18 +34,19 @@ module LogMethod::Log
 
     all_args = [self.class.name, method, object_id, object_class&.name, trace_id, current_actor_id, message]
 
-    after_log_proc = LogMethod.config.after_log_proc
-    arity = if after_log_proc.kind_of?(Proc)
-              after_log_proc.arity
-            elsif after_log_proc.respond_to?(:call)
-              after_log_proc.method(:call).arity
-            end
-    args_for_arity = if arity <= 0
-                       []
-                     else
-                       all_args[0..(arity-1)]
-                     end
-    after_log_proc.(*args_for_arity)
+    LogMethod.config.after_log_procs.each do |after_log_proc|
+      arity = if after_log_proc.kind_of?(Proc)
+                after_log_proc.arity
+              elsif after_log_proc.respond_to?(:call)
+                after_log_proc.method(:call).arity
+              end
+      args_for_arity = if arity <= 0
+                         []
+                       else
+                         all_args[0..(arity-1)]
+                       end
+      after_log_proc.(*args_for_arity)
+    end
   end
 
 private

--- a/lib/log_method/open_telemetry_after_log.rb
+++ b/lib/log_method/open_telemetry_after_log.rb
@@ -1,0 +1,18 @@
+class LogMethod::OpenTelemetryAfterLog
+  def self.call(class_thats_logging_name, method_name, object_id, object_class_name, trace_id, current_actor_id, log_message)
+    current_actor_id_attribute = "app.#{LogMethod.config.current_actor_id_label}"
+
+    OpenTelemetry::Trace.current_span.add_event(
+      log_message,
+      attributes: {
+        "log_method.class_name"        => class_thats_logging_name,
+        "log_method.method_name"       => method_name,
+        "log_method.object_id"         => object_id,
+        "log_method.object_class_name" => object_class_name,
+        "app.trace_id"                 => trace_id,
+        current_actor_id_attribute     => current_actor_id,
+      }
+    )
+  end
+end
+

--- a/spec/bugnsag_after_log_spec.rb
+++ b/spec/bugnsag_after_log_spec.rb
@@ -36,7 +36,26 @@ RSpec.describe LogMethod::BugsnagAfterLog do
           object_id: 42,
           object_class: SomeActiveRecord.name,
           trace_id: "some trace id",
-          admin_user_id: "some actor id",
+          current_actor_id: "some actor id",
+        },
+        Bugsnag::Breadcrumbs::LOG_BREADCRUMB_TYPE
+      )
+    end
+    it "calls uses the configured current_actor_id_label instead of current_actor_id, if set" do
+      LogMethod.config.trace_id_proc = ->() { "some trace id" }
+      LogMethod.config.current_actor_proc = ->() { "some actor id" }
+      LogMethod.config.current_actor_id_label = "user_id"
+
+      ThingThatLogs.new.log :some_method, SomeActiveRecord.new(42), "test message"
+
+      expect(Bugsnag).to have_received(:leave_breadcrumb).with(
+        "some_method",
+        {
+          class: ThingThatLogs.name,
+          object_id: 42,
+          object_class: SomeActiveRecord.name,
+          trace_id: "some trace id",
+          user_id: "some actor id",
         },
         Bugsnag::Breadcrumbs::LOG_BREADCRUMB_TYPE
       )

--- a/spec/open_telemetry_after_log_spec.rb
+++ b/spec/open_telemetry_after_log_spec.rb
@@ -1,0 +1,69 @@
+require "log_method"
+require "log_method/open_telemetry_after_log"
+require "support/fake_rails"
+require "support/helper_classes"
+
+RSpec.describe LogMethod::OpenTelemetryAfterLog do
+
+  class FakeOpenTelemetrySpan
+    attr_reader :log_message, :attributes
+
+    def initialize
+      @log_message = nil
+      @attributes = nil
+    end
+
+    def add_event(log_message, attributes:)
+      @log_message = log_message
+      @attributes = attributes
+    end
+
+  end
+
+  module OpenTelemetry
+    module Trace
+      def self.current_span
+        @current_span ||= FakeOpenTelemetrySpan.new
+      end
+    end
+  end
+
+  describe "#call" do
+    let(:logger) { double("Logger") }
+    before do
+      allow(Rails).to receive(:logger).and_return(logger)
+      allow(logger).to receive(:info)
+      LogMethod.config.reset!
+      LogMethod.config.after_log_proc = LogMethod::OpenTelemetryAfterLog
+    end
+    it "calls into OpenTelemetry's current_span's add_event method" do
+      LogMethod.config.trace_id_proc = ->() { "some trace id" }
+      LogMethod.config.current_actor_proc = ->() { "some actor id" }
+
+      ThingThatLogs.new.log :some_method, SomeActiveRecord.new(42), "test message"
+
+
+      fake_span = OpenTelemetry::Trace.current_span
+
+      expect(fake_span.log_message).to                                eq("test message")
+      expect(fake_span.attributes["log_method.class_name"]).to        eq(ThingThatLogs.name)
+      expect(fake_span.attributes["log_method.method_name"]).to       eq(:some_method)
+      expect(fake_span.attributes["log_method.object_id"]).to         eq(42)
+      expect(fake_span.attributes["log_method.object_class_name"]).to eq(SomeActiveRecord.name)
+      expect(fake_span.attributes["app.trace_id"]).to                 eq("some trace id")
+      expect(fake_span.attributes["app.current_actor_id"]).to         eq("some actor id")
+    end
+    it "uses the current_actor_id_label if given" do
+      LogMethod.config.trace_id_proc = ->() { "some trace id" }
+      LogMethod.config.current_actor_proc = ->() { "some actor id" }
+      LogMethod.config.current_actor_id_label = "user_id"
+
+      ThingThatLogs.new.log :some_method, SomeActiveRecord.new(42), "test message"
+
+
+      fake_span = OpenTelemetry::Trace.current_span
+
+      expect(fake_span.attributes["app.user_id"]).to eq("some actor id")
+    end
+  end
+end


### PR DESCRIPTION
## allow an array of procs if more than one is needed

If you have more than one proc to run as the "after proc", you have to make a proc that calls both. That is annoying.  now `after_log_proc`
can accept an array of procs, and each will be called.

## add open telemetry after proc

This adds an `after_log_proc` for OpenTelemetry that adds an event to the current span.

## fix bug with attribute name of current actor

The Bugsnag `after_log_proc` was using `admin_user_id` for the current actor. That is what the value is called in some of Mood's system, but
this is neither common nor consistent.  instead, fixes it to use the value for `current_actor_id_label`.
