### PR TITLE
support for 3.1, remove 2.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,35 +1,98 @@
-version: 2.1
-orbs:
-  # See https://circleci.com/developer/orbs/orb/circleci/ruby
-  ruby: circleci/ruby@1.2.0
-jobs:                # keyword
-  test:              # my name for the job
-    parameters:      # keyword
-      ruby-version:  # my parameter name
-        type: string # type is a keyword
-    docker:          # keyword
-      - image: cimg/base:stable
-    steps:                                       # keyword
-      - checkout                                 # magic name
-      - ruby/install:                            # ruby/ is from the orb name, install is a command in that orb
-          version: << parameters.ruby-version >> # magic nonsense for param subst
-      - run:
-          command: "bin/setup"
-      - run:
-          name: "Create the test results directory because you can't just store_test_results with a file and if you do you do not get any sort of error because wtf is with this platform?"
-          command: mkdir -p /tmp/test-results
-      - run:
-          command: bin/ci /tmp/test-results/rspec_results.xml
-      - store_test_results:                      # store_test_results is magic from circle
-          path: /tmp/test-results                # path is a param to store_test_results and it must be a directory not a file
-      - store_artifacts:                         # store_artifacts is magic from circle
-          path: /tmp/test-results                # path is the param to store_artifacts
-workflows:              # keyword
-  all-rubies:           # my name for the workflow
-    jobs:               # keyword
-      - test:           # my name for the job
-          matrix:       # keyword
-            parameters: # keyword
-              # All rubies being maintained per this page:
-              # https://www.ruby-lang.org/en/downloads/branches/
-              ruby-version: [ "2.5", "2.6", "2.7", "3.0" ]
+# THIS IS GENERATED - DO NOT EDIT
+# regenerate with bin/mk_circle_config
+# You are very welcome
+---
+version: '2.1'
+jobs:
+  ruby__2_6:
+    docker:
+    - image: cimg/ruby:2.6
+    steps:
+    - checkout
+    - run:
+        name: Setup for build
+        command: bin/setup
+    - run:
+        name: Ensure bin/setup is idempotent
+        command: bin/setup
+    - run:
+        name: Create the test results dir
+        command: mkdir -p /tmp/test-results/2.6
+    - run:
+        name: Run all tests
+        command: bin/ci /tmp/test-results/2.6/rspec_results.xml
+    - store_test_results:
+        path: "/tmp/test-results/2.6"
+    - store_artifacts:
+        path: "/tmp/test-results/2.6"
+  ruby__2_7:
+    docker:
+    - image: cimg/ruby:2.7
+    steps:
+    - checkout
+    - run:
+        name: Setup for build
+        command: bin/setup
+    - run:
+        name: Ensure bin/setup is idempotent
+        command: bin/setup
+    - run:
+        name: Create the test results dir
+        command: mkdir -p /tmp/test-results/2.7
+    - run:
+        name: Run all tests
+        command: bin/ci /tmp/test-results/2.7/rspec_results.xml
+    - store_test_results:
+        path: "/tmp/test-results/2.7"
+    - store_artifacts:
+        path: "/tmp/test-results/2.7"
+  ruby__3_0:
+    docker:
+    - image: cimg/ruby:3.0
+    steps:
+    - checkout
+    - run:
+        name: Setup for build
+        command: bin/setup
+    - run:
+        name: Ensure bin/setup is idempotent
+        command: bin/setup
+    - run:
+        name: Create the test results dir
+        command: mkdir -p /tmp/test-results/3.0
+    - run:
+        name: Run all tests
+        command: bin/ci /tmp/test-results/3.0/rspec_results.xml
+    - store_test_results:
+        path: "/tmp/test-results/3.0"
+    - store_artifacts:
+        path: "/tmp/test-results/3.0"
+  ruby__3_1:
+    docker:
+    - image: cimg/ruby:3.1
+    steps:
+    - checkout
+    - run:
+        name: Setup for build
+        command: bin/setup
+    - run:
+        name: Ensure bin/setup is idempotent
+        command: bin/setup
+    - run:
+        name: Create the test results dir
+        command: mkdir -p /tmp/test-results/3.1
+    - run:
+        name: Run all tests
+        command: bin/ci /tmp/test-results/3.1/rspec_results.xml
+    - store_test_results:
+        path: "/tmp/test-results/3.1"
+    - store_artifacts:
+        path: "/tmp/test-results/3.1"
+workflows:
+  version: 2
+  all_rubies:
+    jobs:
+    - ruby__2_6
+    - ruby__2_7
+    - ruby__3_0
+    - ruby__3_1

--- a/bin/mk_circle_config
+++ b/bin/mk_circle_config
@@ -1,0 +1,84 @@
+#!/usr/bin/env ruby
+
+require "yaml"
+require "pathname"
+
+circle_config = {
+  "version" => "2.1",
+  "jobs" => {},
+  "workflows" => {
+    "version" => 2,
+    "all_rubies" => {
+      "jobs" => [
+      ],
+    },
+  }
+}
+
+supported_rubies = [
+  "2.6",
+  "2.7",
+  "3.0",
+  "3.1",
+]
+
+supported_rubies.each do |ruby_verison|
+
+  test_results_dir = "/tmp/test-results/#{ruby_verison}"
+  job_name = "ruby__#{ruby_verison.gsub(/\./,"_")}"
+
+  job = {
+    "docker" => [
+      {
+        "image" => "cimg/ruby:#{ruby_verison}",
+      }
+    ],
+    "steps" => [
+      "checkout",
+      {
+        "run" => {
+          "name" => "Setup for build",
+          "command" => "bin/setup",
+        }
+      },
+      {
+        "run" => {
+          "name" => "Ensure bin/setup is idempotent",
+          "command" => "bin/setup",
+        }
+      },
+      {
+        "run" => {
+          "name" => "Create the test results dir",
+          "command" => "mkdir -p #{test_results_dir}",
+        }
+      },
+      {
+        "run" => {
+          "name" => "Run all tests",
+          "command" => "bin/ci #{test_results_dir}/rspec_results.xml",
+        }
+      },
+      {
+        "store_test_results" => {
+          "path" => test_results_dir,
+        }
+      },
+      {
+        "store_artifacts" => {
+          "path" => test_results_dir,
+        }
+      },
+    ]
+  }
+  circle_config["jobs"][job_name] = job
+  circle_config["workflows"]["all_rubies"]["jobs"] << job_name
+end
+
+circle_config_file = (Pathname(__FILE__).dirname / ".." / ".circleci" / "config.yml").expand_path
+File.open(circle_config_file,"w") do |file|
+  file.puts "# THIS IS GENERATED - DO NOT EDIT"
+  file.puts "# regenerate with bin/mk_circle_config"
+  file.puts "# You are very welcome"
+  file.puts circle_config.to_yaml
+end


### PR DESCRIPTION
This removes the use of Circle's Ruby ORB which does not seem to be maintained and also has a depdendency on RVM stable, which has not had a release in over a year.

`bin/mk_circle_config` will now create the requisite YAML for circle to do the build matrix I need.