### PR TITLE
use tagged instead of custom messages

### DIFF
--- a/lib/log_method/log.rb
+++ b/lib/log_method/log.rb
@@ -1,3 +1,5 @@
+require "active_support/tagged_logging"
+
 module LogMethod::Log
   def logging_external_identifier_method
     @logging_external_identifier_method ||=  LogMethod.config.external_identifier_method
@@ -7,30 +9,20 @@ module LogMethod::Log
 
     trace_id         = LogMethod.config.trace_id_proc.()
     current_actor_id = LogMethod.config.current_actor_proc.()
+    object_id        = nil
+    object_class     = nil
 
-    object_identifier_phrase = ""
-
+    logger = Rails.logger.tagged("#{self.class}##{method}").tagged("via LogMethod::Log")
     if message.nil?
       message = message_or_object
     else
-      object_id,object_class = if !logging_external_identifier_method.nil? &&
-                                   message_or_object.respond_to?(logging_external_identifier_method)
-
-                                 [message_or_object.send(logging_external_identifier_method), message_or_object.class]
-
-                               elsif message_or_object.kind_of?(ActiveRecord::Base)
-
-                                 [message_or_object.id, message_or_object.class]
-
-                               else
-
-                                 [message_or_object.inspect, message_or_object.class]
-
-                               end
-      object_identifier_phrase = "[#{object_class}/#{object_id}]: "
+      object_id, object_class = extract_object_identifier(message_or_object)
+      logger = logger.tagged("#{object_class}/#{object_id}")
     end
+    logger = logger_with_trace_id(logger,trace_id)
+    logger = logger_with_current_actor_id(logger,current_actor_id)
 
-    Rails.logger.info("[#{self.class}##{method}](via LogMethod::Log)#{format_trace_id(trace_id)}#{format_current_actor_id(current_actor_id)}: #{object_identifier_phrase}#{message}")
+    logger.info(message)
 
     all_args = [self.class.name, method, object_id, object_class&.name, trace_id, current_actor_id, message]
 
@@ -51,13 +43,30 @@ module LogMethod::Log
 
 private
 
-  def format_trace_id(trace_id)
-    return nil if trace_id.nil?
-    " trace_id:#{trace_id} "
+  def extract_object_identifier(message_or_object)
+    if !logging_external_identifier_method.nil? &&
+        message_or_object.respond_to?(logging_external_identifier_method)
+
+      [message_or_object.send(logging_external_identifier_method), message_or_object.class]
+
+    elsif message_or_object.kind_of?(ActiveRecord::Base)
+
+      [message_or_object.id, message_or_object.class]
+
+    else
+
+      [message_or_object.inspect, message_or_object.class]
+
+    end
   end
 
-  def format_current_actor_id(current_actor_id)
-    return nil if current_actor_id.nil?
-    " #{LogMethod.config.current_actor_id_label}:#{current_actor_id} "
+  def logger_with_trace_id(logger,trace_id)
+    return logger if trace_id.nil?
+    logger.tagged("trace_id:#{trace_id}")
+  end
+
+  def logger_with_current_actor_id(logger,current_actor_id)
+    return logger if current_actor_id.nil?
+    logger.tagged("#{LogMethod.config.current_actor_id_label}:#{current_actor_id}")
   end
 end

--- a/log_method.gemspec
+++ b/log_method.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_runtime_dependency("activesupport")
   spec.add_development_dependency("rspec")
   spec.add_development_dependency("rspec_junit_formatter")
 end

--- a/spec/bugnsag_after_log_spec.rb
+++ b/spec/bugnsag_after_log_spec.rb
@@ -14,11 +14,12 @@ RSpec.describe LogMethod::BugsnagAfterLog do
     end
   end
   describe "#call" do
-    let(:logger) { double("Logger") }
+
+    let(:logger) { Logger.new(StringIO.new) }
+
     before do
       allow(Bugsnag).to receive(:leave_breadcrumb)
-      allow(Rails).to receive(:logger).and_return(logger)
-      allow(logger).to receive(:info)
+      allow(Logger).to receive(:new).and_return(logger)
 
       LogMethod.config.reset!
       LogMethod.config.after_log_proc = LogMethod::BugsnagAfterLog

--- a/spec/log_spec.rb
+++ b/spec/log_spec.rb
@@ -5,11 +5,11 @@ require "support/helper_classes"
 RSpec.describe LogMethod::Log do
 
   describe "#log" do
-    let(:logger) { double("Logger") }
+    let(:log_dev) { StringIO.new }
+    let(:logger) { Logger.new(log_dev, level: :info, progname: "rspec") }
 
     before do
-      allow(Rails).to receive(:logger).and_return(logger)
-      allow(logger).to receive(:info)
+      allow(Logger).to receive(:new).and_return(logger)
 
       LogMethod.config.reset!
     end
@@ -21,9 +21,9 @@ RSpec.describe LogMethod::Log do
           object.log :some_method, "this is a test message"
 
           aggregate_failures do
-            expect(logger).to have_received(:info).with(/ThingThatLogs/)
-            expect(logger).to have_received(:info).with(/some_method/)
-            expect(logger).to have_received(:info).with(/this is a test message/)
+            expect(log_dev.string).to match(/ThingThatLogs/)
+            expect(log_dev.string).to match(/some_method/)
+            expect(log_dev.string).to match(/this is a test message/)
           end
         end
       end
@@ -34,7 +34,7 @@ RSpec.describe LogMethod::Log do
             object.log :some_method, SomeActiveRecord.new(999), "this is a test message"
 
             aggregate_failures do
-              expect(logger).to have_received(:info).with(/SomeActiveRecord\/999/)
+              expect(log_dev.string).to match(/SomeActiveRecord\/999/)
             end
           end
         end
@@ -46,7 +46,7 @@ RSpec.describe LogMethod::Log do
             object.log :some_method, ThingWithoutExternalId.new(inspect_output), "this is a test message"
 
             aggregate_failures do
-              expect(logger).to have_received(:info).with(/ThingWithoutExternalId\/#{Regexp.escape(inspect_output)}/)
+              expect(log_dev.string).to match(/ThingWithoutExternalId\/#{Regexp.escape(inspect_output)}/)
             end
           end
         end
@@ -232,7 +232,7 @@ RSpec.describe LogMethod::Log do
 
           object = ThingThatLogs.new
           object.log :some_method, "this is a test message"
-          expect(logger).to have_received(:info).with(/user_id:some actor id/)
+          expect(log_dev.string).to match(/user_id:some actor id/)
         end
       end
       context "default current_actor_id_label" do
@@ -241,7 +241,7 @@ RSpec.describe LogMethod::Log do
 
           object = ThingThatLogs.new
           object.log :some_method, "this is a test message"
-          expect(logger).to have_received(:info).with(/current_actor_id:some actor id/)
+          expect(log_dev.string).to match(/current_actor_id:some actor id/)
         end
       end
     end
@@ -251,7 +251,7 @@ RSpec.describe LogMethod::Log do
 
         object = ThingThatLogs.new
         object.log :some_method, ThingWithExternalId.new("foobar id"), "this is a test message"
-        expect(logger).to have_received(:info).with(/foobar id/)
+        expect(log_dev.string).to match(/foobar id/)
       end
     end
     context "using trace_id_proc" do
@@ -260,7 +260,7 @@ RSpec.describe LogMethod::Log do
 
         object = ThingThatLogs.new
         object.log :some_method, "this is a test message"
-        expect(logger).to have_received(:info).with(/some trace id/)
+        expect(log_dev.string).to match(/some trace id/)
       end
     end
   end

--- a/spec/open_telemetry_after_log_spec.rb
+++ b/spec/open_telemetry_after_log_spec.rb
@@ -29,10 +29,9 @@ RSpec.describe LogMethod::OpenTelemetryAfterLog do
   end
 
   describe "#call" do
-    let(:logger) { double("Logger") }
+    let(:logger) { Logger.new(StringIO.new) }
     before do
-      allow(Rails).to receive(:logger).and_return(logger)
-      allow(logger).to receive(:info)
+      allow(Logger).to receive(:new).and_return(logger)
       LogMethod.config.reset!
       LogMethod.config.after_log_proc = LogMethod::OpenTelemetryAfterLog
     end

--- a/spec/paper_trail_current_actor_spec.rb
+++ b/spec/paper_trail_current_actor_spec.rb
@@ -12,11 +12,11 @@ RSpec.describe LogMethod::PaperTrailCurrentActor do
     end
   end
   describe "#call" do
-    let(:logger) { double("Logger") }
+    let(:log_dev) { StringIO.new }
+    let(:logger) { Logger.new(log_dev, level: :info) }
     before do
       allow(Bugsnag).to receive(:leave_breadcrumb)
-      allow(Rails).to receive(:logger).and_return(logger)
-      allow(logger).to receive(:info)
+      allow(Logger).to receive(:new).and_return(logger)
 
       LogMethod.config.reset!
       LogMethod.config.current_actor_proc = LogMethod::PaperTrailCurrentActor
@@ -25,7 +25,7 @@ RSpec.describe LogMethod::PaperTrailCurrentActor do
 
       ThingThatLogs.new.log :some_method, "test message"
 
-      expect(logger).to have_received(:info).with(/current_actor_id:some actor id/)
+      expect(log_dev.string).to match(/current_actor_id:some actor id/)
     end
   end
 end

--- a/spec/support/fake_rails.rb
+++ b/spec/support/fake_rails.rb
@@ -1,7 +1,8 @@
-# Don't want to have this gem depend on all of Rails just for testing
+require "active_support/tagged_logging"
+require "active_support/isolated_execution_state"
 module Rails
   def self.logger
-    Object.new
+    ActiveSupport::TaggedLogging.new(Logger.new($stdout))
   end
 end
 module ActiveRecord

--- a/spec/support/fake_rails.rb
+++ b/spec/support/fake_rails.rb
@@ -1,5 +1,8 @@
 require "active_support/tagged_logging"
-require "active_support/isolated_execution_state"
+major,minor,_ = RUBY_VERSION.split(/\./).map(&:to_i)
+if (major > 2) || ((major == 2) && (minor > 6))
+  require "active_support/isolated_execution_state"
+end
 module Rails
   def self.logger
     ActiveSupport::TaggedLogging.new(Logger.new($stdout))


### PR DESCRIPTION
Using `logger.tagged` is more canonical with Rails than building up a complicated message by hand.
